### PR TITLE
fix(): Return error code if dns resolution fails

### DIFF
--- a/plugin/kubeslice/handler_test.go
+++ b/plugin/kubeslice/handler_test.go
@@ -34,9 +34,8 @@ var _ = Describe("Handler", func() {
 
 			code, err := ks.ServeDNS(context.Background(), w, r)
 
-			Expect(err).ToNot(HaveOccurred())
-			Expect(code).To(Equal(dns.RcodeSuccess))
-			Expect(w.Msg.Answer).To(HaveLen(0))
+			Expect(err).To(HaveOccurred())
+			Expect(code).To(Equal(dns.RcodeNameError))
 		})
 
 		It("should return correct A record", func() {
@@ -127,9 +126,8 @@ var _ = Describe("Handler", func() {
 
 			code, err := ks.ServeDNS(context.Background(), w, r)
 
-			Expect(err).ToNot(HaveOccurred())
-			Expect(code).To(Equal(dns.RcodeSuccess))
-			Expect(w.Msg.Answer).To(HaveLen(0))
+			Expect(err).To(HaveOccurred())
+			Expect(code).To(Equal(dns.RcodeNotImplemented))
 		})
 
 		It("benchmark dns query", Serial, Label("measurement"), func() {
@@ -162,8 +160,8 @@ var _ = Describe("Handler", func() {
 			experiment.Sample(func(idx int) {
 				experiment.MeasureDuration("dns-query", func() {
 					code, err := ks.ServeDNS(context.Background(), w, r)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(code).To(Equal(dns.RcodeSuccess))
+					Expect(err).To(HaveOccurred())
+					Expect(code).To(Equal(dns.RcodeNotImplemented))
 				})
 			}, gmeasure.SamplingConfig{N: 10, Duration: time.Minute})
 

--- a/plugin/kubeslice/kubeslice.go
+++ b/plugin/kubeslice/kubeslice.go
@@ -21,14 +21,6 @@ func (ks *Kubeslice) Services(ctx context.Context, state request.Request, exact 
 
 	var svcs []msg.Service
 
-	// kubeslice only support A records for now, so return empty list if request is not A
-	if state.QType() != dns.TypeA {
-		log.Debug("received invalid request type, only A is supported now")
-		return svcs, nil
-	}
-
-	log.Info("fetching kubeslice services")
-
 	name := state.Name()
 	name = name[:len(name)-1]
 


### PR DESCRIPTION
The kubeslice-dns plugin does not return an error code if the resolution
fails due to unsupported query type or if records are not found for the
domain name. It returns a success code instead with an empty Answers 
section. This can cause certain dns client and dns proxies to 
misinterpret the response and to cache responses with empty Answers.

Added this fix to return appropriate error codes.