### PR TITLE
fix(): Reverting previous commit

### DIFF
--- a/plugin/kubeslice/handler.go
+++ b/plugin/kubeslice/handler.go
@@ -2,7 +2,6 @@ package kubeslice
 
 import (
 	"context"
-	"errors"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
@@ -17,26 +16,16 @@ var log = clog.NewWithPlugin("kubeslice")
 
 // ServeDNS implements the plugin.Handler interface.
 func (ks Kubeslice) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	log.Debug("Question type", r.Question)
+
 	state := request.Request{W: w, Req: r}
 	zone := "slice.local"
 
-	// kubeslice only support A records for now, so return empty list if request is not A
-        if state.QType() != dns.TypeA {
-                log.Debug("received invalid request type, only A is supported now", r.Question)
-                return dns.RcodeNotImplemented, errors.New("Request type not supported")
-        }
-
 	records, truncated, err := plugin.A(ctx, &ks, zone, state, nil, plugin.Options{})
+
 	if err != nil {
-		log.Debug("Error", err)
 		return dns.RcodeServerFailure, err
 	}
-	if len(records) == 0 {
-		log.Debug("Error", "No records found")
-		return dns.RcodeNameError, errors.New("No records found")
-	}
-
-	log.Debug("Records", records)
 
 	m := new(dns.Msg)
 	m.SetReply(r)

--- a/plugin/kubeslice/handler_test.go
+++ b/plugin/kubeslice/handler_test.go
@@ -34,8 +34,9 @@ var _ = Describe("Handler", func() {
 
 			code, err := ks.ServeDNS(context.Background(), w, r)
 
-			Expect(err).To(HaveOccurred())
-			Expect(code).To(Equal(dns.RcodeNameError))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(code).To(Equal(dns.RcodeSuccess))
+			Expect(w.Msg.Answer).To(HaveLen(0))
 		})
 
 		It("should return correct A record", func() {
@@ -126,8 +127,9 @@ var _ = Describe("Handler", func() {
 
 			code, err := ks.ServeDNS(context.Background(), w, r)
 
-			Expect(err).To(HaveOccurred())
-			Expect(code).To(Equal(dns.RcodeNotImplemented))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(code).To(Equal(dns.RcodeSuccess))
+			Expect(w.Msg.Answer).To(HaveLen(0))
 		})
 
 		It("benchmark dns query", Serial, Label("measurement"), func() {
@@ -160,8 +162,8 @@ var _ = Describe("Handler", func() {
 			experiment.Sample(func(idx int) {
 				experiment.MeasureDuration("dns-query", func() {
 					code, err := ks.ServeDNS(context.Background(), w, r)
-					Expect(err).To(HaveOccurred())
-					Expect(code).To(Equal(dns.RcodeNotImplemented))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(code).To(Equal(dns.RcodeSuccess))
 				})
 			}, gmeasure.SamplingConfig{N: 10, Duration: time.Minute})
 

--- a/plugin/kubeslice/kubeslice.go
+++ b/plugin/kubeslice/kubeslice.go
@@ -21,6 +21,14 @@ func (ks *Kubeslice) Services(ctx context.Context, state request.Request, exact 
 
 	var svcs []msg.Service
 
+	// kubeslice only support A records for now, so return empty list if request is not A
+	if state.QType() != dns.TypeA {
+		log.Debug("received invalid request type, only A is supported now")
+		return svcs, nil
+	}
+
+	log.Info("fetching kubeslice services")
+
 	name := state.Name()
 	name = name[:len(name)-1]
 


### PR DESCRIPTION
Reverting "fix(): Return error code if dns resolution fails" for now. Some more changes are needed in the nsm dns proxy to properly handle the returned error codes.